### PR TITLE
Item Create & Destroy

### DIFF
--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -8,7 +8,13 @@ class Api::V1::ItemsController < ApplicationController
   end
 
   def create
-    render json: Item.create!(item_params)
+    render json: ItemSerializer.new(Item.create(item_params))
+  end
+
+  def destroy
+    Item.destroy(params[:id])
+    # render body: nil, status: :no_content
+    # render json: Item.delete(params[:id])
   end
 
   private

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -6,4 +6,13 @@ class Api::V1::ItemsController < ApplicationController
   def show
     render json: ItemSerializer.new(Item.find(params[:id]))
   end
+
+  def create
+    render json: Item.create!(item_params)
+  end
+
+  private
+    def item_params
+      params.require(:item).permit(:name, :description, :unit_price, :merchant_id)
+    end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :merchants, only: [ :index, :show ]
-      resources :items, only: [ :index, :show, :create ] 
+      resources :items, only: [ :index, :show, :create, :destroy ] 
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :merchants, only: [ :index, :show ]
-      resources :items, only: [ :index, :show ] 
+      resources :items, only: [ :index, :show, :create ] 
     end
   end
 end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -73,4 +73,25 @@ describe "Items API" do
     expect(item[:data][:attributes][:merchant_id]).to eq Item.find(item[:data][:id])[:merchant_id]
     expect(item[:data][:attributes][:merchant_id]).to be_an(Integer)
   end
+
+  it "can create a new item" do
+    merchant = create(:merchant)
+    item_params = ({
+                    name: Faker::Food.dish,
+                    description: Faker::Food.description,
+                    unit_price: Faker::Number.decimal(r_digits: 2),
+                    merchant_id: merchant.id
+                  })
+
+    headers = {"CONTENT_TYPE" => "application/json"}
+
+    post "/api/v1/items", headers: headers, params: JSON.generate(item: item_params)
+    created_item = Item.last
+
+    expect(response).to be_successful
+    expect(created_item.name).to eq(item_params[:name])
+    expect(created_item.description).to eq(item_params[:description])
+    expect(created_item.unit_price).to eq(item_params[:unit_price])
+    expect(created_item.merchant_id).to eq(item_params[:merchant_id])
+  end
 end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -86,6 +86,31 @@ describe "Items API" do
     headers = {"CONTENT_TYPE" => "application/json"}
 
     post "/api/v1/items", headers: headers, params: JSON.generate(item: item_params)
+
+    item = JSON.parse(response.body, symbolize_names: true)
+
+    expect(item[:data]).to have_key(:id)
+    expect(item[:data][:id]).to be_an(String)
+
+    expect(item[:data]).to have_key(:type)
+    expect(item[:data][:type]).to be_an(String)
+    expect(item[:data][:type]).to eq('item')
+
+    expect(item[:data]).to have_key(:attributes)
+    expect(item[:data][:attributes]).to be_an(Hash)
+
+    expect(item[:data][:attributes][:name]).to eq Item.find(item[:data][:id])[:name]
+    expect(item[:data][:attributes][:name]).to be_an(String)
+
+    expect(item[:data][:attributes][:description]).to eq Item.find(item[:data][:id])[:description]
+    expect(item[:data][:attributes][:description]).to be_an(String)
+
+    expect(item[:data][:attributes][:unit_price]).to eq Item.find(item[:data][:id])[:unit_price]
+    expect(item[:data][:attributes][:unit_price]).to be_an(Float)
+
+    expect(item[:data][:attributes][:merchant_id]).to eq Item.find(item[:data][:id])[:merchant_id]
+    expect(item[:data][:attributes][:merchant_id]).to be_an(Integer)
+
     created_item = Item.last
 
     expect(response).to be_successful
@@ -94,4 +119,30 @@ describe "Items API" do
     expect(created_item.unit_price).to eq(item_params[:unit_price])
     expect(created_item.merchant_id).to eq(item_params[:merchant_id])
   end
+
+  it "can destroy an item" do
+    merchant = create(:merchant)
+    item = create(:item, merchant_id: merchant.id)
+
+    expect(Item.count).to eq(1)
+
+    delete "/api/v1/items/#{item.id}"
+
+    expect(response).to be_successful
+    expect(response.status).to eq 204
+    # expect(response.body).to eq nil
+    expect(Item.count).to eq(0)
+    expect{Item.find(item.id)}.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  # # Extra check
+  # it "can destroy an item" do
+  #   merchant = create(:merchant)
+  #   item = create(:item, merchant_id: merchant.id)
+
+  #   expect{ delete "/api/v1/items/#{item.id}" }.to change(Item, :count).by(-1)
+
+  #   expect(response).to be_success
+  #   expect{Item.find(item.id)}.to raise_error(ActiveRecord::RecordNotFound)
+  # end
 end


### PR DESCRIPTION
Adds tests and functionality to call for Merchant Create and Destroy.

**Currently passes spec tests, but does not pass Postman tests. Need to reevaluate at a later date.**